### PR TITLE
Moved function documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,12 +37,13 @@ fn write_range<W: Write>(dest: &mut W, range: &Range<DataType>) -> std::io::Resu
     Ok(())
 }
 
-/// Formats the sum of two numbers as string.
+// converts first argument into a csv (same name, silently overrides if the file already exists)
+// second argument is the sheet name
+// returns true if successful
+// panics if the first argument is not an excel file
+// panics if the second argument is not a sheet name or does not exist
 #[pyfunction]
 fn xlsx2csv(file: &str, sheet: &str) -> PyResult<bool> {
-    // converts first argument into a csv (same name, silently overrides
-    // if the file already exists
-
     let src = PathBuf::from(file);
     match src.extension().and_then(|s| s.to_str()) {
         Some("xlsx") | Some("xlsm") | Some("xlsb") | Some("xls") => (),


### PR DESCRIPTION
I must disclaim that I'm not that familiar with Rust and had some problems compiling it, so please test it.

But I noticed that
```python
import xlsx_csv
help(xlsx_csv.xlsx2csv)
```
would show the comment above the function but it wasn't helpful.
Hopefully, this improves it.